### PR TITLE
Gradle: Fix build dependencies on all the modules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,12 +6,13 @@ buildscript {
         legacy_support_v4_version = '1.0.0'
         recyclerview_version = '1.2.1'
         lifecycle_runtime_ktx_version = '2.3.1'
-        compose_version = '1.4.0-alpha03'
-        wear_compose_version = '1.2.0-alpha01'
+        compose_version = '1.4.0-alpha04'
+        wear_compose_version = '1.2.0-alpha02'
         activity_compose_version = '1.6.1'
+        work_version = '2.7.1'
 
         tflite_version = '2.10.0'
-        room_version = '2.4.3'
+        room_version = '2.5.0'
 
         truth_version = '1.1.3'
         mockk_version = '1.13.2'

--- a/build.gradle
+++ b/build.gradle
@@ -20,9 +20,9 @@ buildscript {
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.3.1' apply false
-    id 'com.android.library' version '7.3.1' apply false
-    id 'org.jetbrains.kotlin.android' version '1.6.10' apply false
+    id 'com.android.application' version '7.4.0' apply false
+    id 'com.android.library' version '7.4.0' apply false
+    id 'org.jetbrains.kotlin.android' version '1.6.21' apply false
     id 'de.mannodermaus.android-junit5' version '1.8.2.1' apply false
     id "org.jlleitschuh.gradle.ktlint" version '11.0.0' apply false
 }

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
 plugins {
     id 'com.android.application' version '7.4.0' apply false
     id 'com.android.library' version '7.4.0' apply false
-    id 'org.jetbrains.kotlin.android' version '1.6.21' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.20' apply false
     id 'de.mannodermaus.android-junit5' version '1.8.2.1' apply false
     id "org.jlleitschuh.gradle.ktlint" version '11.0.0' apply false
 }

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,8 @@ buildscript {
         mockk_version = '1.13.2'
         junit_version = '5.8.2'
     }
-}// Top-level build file where you can add configuration options common to all sub-projects/modules.
+}
+
 plugins {
     id 'com.android.application' version '7.4.0' apply false
     id 'com.android.library' version '7.4.0' apply false

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,27 @@
 buildscript {
     ext {
-        compose_version = '1.4.0-alpha02'
-        wear_compose_version = '1.1.0-rc01'
+        core_ktx_version = '1.9.0'
+        play_services_wearable_version = '18.0.0'
+        percentlayout_version = '1.0.0'
+        legacy_support_v4_version = '1.0.0'
+        recyclerview_version = '1.2.1'
+        lifecycle_runtime_ktx_version = '2.3.1'
+        compose_version = '1.4.0-alpha03'
+        wear_compose_version = '1.2.0-alpha01'
+        activity_compose_version = '1.6.1'
+
         tflite_version = '2.10.0'
-        junit_version = '5.8.2'
         room_version = '2.4.3'
+
+        truth_version = '1.1.3'
+        mockk_version = '1.13.2'
+        junit_version = '5.8.2'
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id 'com.android.application' version '7.3.1' apply false
     id 'com.android.library' version '7.3.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.6.10' apply false
+    id 'de.mannodermaus.android-junit5' version '1.8.2.1' apply false
+    id "org.jlleitschuh.gradle.ktlint" version '11.0.0' apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Nov 09 10:52:49 CET 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/sensorslib/build.gradle
+++ b/sensorslib/build.gradle
@@ -33,7 +33,7 @@ android {
 
 dependencies {
     implementation "androidx.core:core-ktx:$core_ktx_version"
-    implementation "androidx.appcompat:appcompat:1.5.1"
+    implementation "androidx.appcompat:appcompat:1.6.0"
     implementation "com.google.android.material:material:1.7.0"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_version"

--- a/sensorslib/build.gradle
+++ b/sensorslib/build.gradle
@@ -1,8 +1,8 @@
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
-    id 'de.mannodermaus.android-junit5' version '1.8.2.1'
-    id "org.jlleitschuh.gradle.ktlint" version '11.0.0'
+    id 'de.mannodermaus.android-junit5'
+    id 'org.jlleitschuh.gradle.ktlint'
 }
 
 android {
@@ -32,12 +32,12 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'androidx.appcompat:appcompat:1.5.1'
-    implementation 'com.google.android.material:material:1.7.0'
+    implementation "androidx.core:core-ktx:$core_ktx_version"
+    implementation "androidx.appcompat:appcompat:1.5.1"
+    implementation "com.google.android.material:material:1.7.0"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_version"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit_version"
-    testImplementation "io.mockk:mockk:1.13.2"
-    testImplementation "com.google.truth:truth:1.1.3"
+    testImplementation "io.mockk:mockk:$mockk_version"
+    testImplementation "com.google.truth:truth:$truth_version"
 }

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -38,7 +38,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.1.1'
+        kotlinCompilerExtensionVersion '1.3.2'
     }
     packagingOptions {
         resources {

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -2,8 +2,8 @@ plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
     id 'kotlin-kapt'
-    id 'de.mannodermaus.android-junit5' version '1.8.2.1'
-    id "org.jlleitschuh.gradle.ktlint" version '11.0.0'
+    id 'de.mannodermaus.android-junit5'
+    id 'org.jlleitschuh.gradle.ktlint'
 }
 
 android {
@@ -48,18 +48,18 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'com.google.android.gms:play-services-wearable:18.0.0'
-    implementation 'androidx.percentlayout:percentlayout:1.0.0'
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.recyclerview:recyclerview:1.2.1'
-    implementation "androidx.compose.ui:ui:$compose_version"
+    implementation "androidx.core:core-ktx:$core_ktx_version"
+    implementation "com.google.android.gms:play-services-wearable:$play_services_wearable_version"
+    implementation "androidx.percentlayout:percentlayout:$percentlayout_version"
+    implementation "androidx.legacy:legacy-support-v4:$legacy_support_v4_version"
+    implementation "androidx.recyclerview:recyclerview:$recyclerview_version"
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycle_runtime_ktx_version"
 
+    implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.wear.compose:compose-material:$wear_compose_version"
     implementation "androidx.wear.compose:compose-foundation:$wear_compose_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
-    implementation 'androidx.activity:activity-compose:1.6.1'
+    implementation "androidx.activity:activity-compose:$activity_compose_version"
 
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4'
 
@@ -75,8 +75,8 @@ dependencies {
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_version"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit_version"
-    testImplementation "io.mockk:mockk:1.13.2"
-    testImplementation "com.google.truth:truth:1.1.3"
+    testImplementation "io.mockk:mockk:$mockk_version"
+    testImplementation "com.google.truth:truth:$truth_version"
     testImplementation "androidx.room:room-testing:$room_version"
 
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"


### PR DESCRIPTION
This commit PR reorders all gradle build dependencies for the root project and the submodules.

The versions of all the common dependencies are listed as variables in the root `build.gradle` so that all submodules can easily use them.