### PR TITLE
(#26): Mark non-API classes as `internal`

### DIFF
--- a/sensorslib/src/main/java/com/handmonitor/sensorslib/SensorSampleFilter.kt
+++ b/sensorslib/src/main/java/com/handmonitor/sensorslib/SensorSampleFilter.kt
@@ -11,7 +11,7 @@ import java.util.concurrent.TimeUnit
  *
  * @param[samplingMs] The sampling period in milliseconds.
  */
-class SensorSampleFilter(
+internal class SensorSampleFilter(
     samplingMs: Long,
     private val sensorName: String = "unknown"
 ) {

--- a/sensorslib/src/main/java/com/handmonitor/sensorslib/SensorWindowBuffer.kt
+++ b/sensorslib/src/main/java/com/handmonitor/sensorslib/SensorWindowBuffer.kt
@@ -10,7 +10,7 @@ package com.handmonitor.sensorslib
  * @param[windowSize] The size of the processing window; the
  * internal buffer will have a size of windowSize * 6.
  */
-class SensorWindowBuffer(windowSize: Int) {
+internal class SensorWindowBuffer(windowSize: Int) {
     private val mBufferCapacity: Int = windowSize * 6
     private val mBuffer: FloatArray = FloatArray(mBufferCapacity) { 0.0f }
     private var mAccIndex: Int = 0


### PR DESCRIPTION
This commit marks all the classes not related to public API as internal so they cannot be accessed for outside the package.